### PR TITLE
Fix LongCountWildcard equality

### DIFF
--- a/src/__tests__/operations/operations-longcount-wildcard.spec.ts
+++ b/src/__tests__/operations/operations-longcount-wildcard.spec.ts
@@ -32,3 +32,12 @@ it('compute double wildcard', () => {
   const potentialLcs = new LongCountWildcard(lc).run();
   expect(potentialLcs).to.have.lengthOf(300);
 });
+
+it('compare longcount wildcards', () => {
+  const f = new LongCountFactory();
+  const a = new LongCountWildcard(f.parse('1.2.3.4.5'));
+  const b = new LongCountWildcard(f.parse('1.2.3.4.5'));
+  const c = new LongCountWildcard(f.parse('1.2.3.4.6'));
+  expect(a.equal(b)).to.be.true;
+  expect(a.equal(c)).to.be.false;
+});

--- a/src/operations/longcount-wildcard.ts
+++ b/src/operations/longcount-wildcard.ts
@@ -19,7 +19,7 @@ export default class LongCountWildcard extends CommentWrapper implements IPart {
 
   equal(other: IPart): boolean {
     if (other instanceof LongCountWildcard) {
-      return other.lc.equal(other.lc)
+      return this.lc.equal(other.lc)
     }
     return false
   }


### PR DESCRIPTION
## Summary
- fix equality logic for `LongCountWildcard`
- add tests for `LongCountWildcard` equality comparison

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cab6c89f4832f93f478d1511db373