### PR TITLE
Fix README badge image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @drewsonne/maya-dates
 
-![Documentation Coverage](./docs/badge.svg)
+![Documentation Coverage](https://drewsonne.github.io/maya-dates/badge.svg)
 
 A typescript library for interacting with and modifying both the Maya Long Count (LC)
 and Calendar Round (CR) dates.

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@
 				<a href="#drewsonnemaya-dates" id="drewsonnemaya-dates" style="color: inherit; text-decoration: none;">
 					<h1>@drewsonne/maya-dates</h1>
 				</a>
-				<p><img src="./docs/badge.svg" alt="Documentation Coverage"></p>
+				<p><img src="https://drewsonne.github.io/maya-dates/badge.svg" alt="Documentation Coverage"></p>
 				<p>A library for interacting with and modifying both the Maya Long Count (LC)
 				and Calendar Round (CR) dates.</p>
 				<a href="#quickstart" id="quickstart" style="color: inherit; text-decoration: none;">


### PR DESCRIPTION
## Summary
- fix broken documentation badge image in README
- update doc index page to use the absolute badge URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cb17176a0832fa19093f58e93aec0