### PR TITLE
Fix docs publishing token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           publish_dir: ./docs
           destination_dir: maya-dates
           external_repository: drewsonne/drewsonne.github.io


### PR DESCRIPTION
## Summary
- update docs workflow to use a personal token when pushing to drewsonne.github.io

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687cc4896ee0832fb386f5e79e91b5a8