### PR TITLE
docs: Document epoch choice and scholarly rationale

### DIFF
--- a/src/cr/calendar-round.ts
+++ b/src/cr/calendar-round.ts
@@ -181,7 +181,33 @@ export class CalendarRound extends CommentWrapper implements IPart {
   }
 }
 
-/** @ignore */
+/**
+ * The Calendar Round base date: 4 Ajaw 8 Kumk'u.
+ * 
+ * This corresponds to the Maya creation-era base date 13.0.0.0.0 in the Long Count,
+ * which serves as "day zero" (Maya Day Number (MDN) = 0) for all calendrical calculations per [R1, R2].
+ * MDN is analogous to Julian Day Number, but for the Maya calendar system.
+ * 
+ * **Scholarly Rationale:**
+ * - This epoch is explicitly documented in Reingold, Dershowitz, & Clamen (1993) [R1] and 
+ *   Martin & Skidmore (2012) [R2] as the standard anchor for Maya calendar calculations
+ * - The date represents the completion of the 13th bak'tun at the beginning of the 
+ *   current era in Maya cosmology
+ * - Using this epoch ensures compatibility with correlation constants (GMT family: 
+ *   584283, 584285, 584286) which all anchor to this same date
+ * 
+ * **Alternative Epochs:**
+ * While historical dates like royal coronations could theoretically serve as alternative
+ * anchors, changing the epoch would:
+ * 1. Break compatibility with all published correlation constants
+ * 2. Require recalculation of all Haab'/Tzolk'in offset formulas
+ * 3. Diverge from established scholarly practice
+ * 
+ * For these reasons, this implementation follows the standard epoch per academic literature.
+ * 
+ * @see Reingold, Dershowitz, & Clamen (1993) - Calendrical Calculations, II [R1]
+ * @see Martin & Skidmore (2012) - Exploring the 584286 Correlation [R2]
+ */
 export const origin = getCalendarRound(
   getTzolkin(
     new NumberCoefficient(4), getTzolkinDay('Ajaw')),

--- a/src/lc/long-count.ts
+++ b/src/lc/long-count.ts
@@ -11,7 +11,27 @@ import GregorianCalendarDate from "./western/gregorian";
 import {IPart} from "../i-part";
 
 /**
- * Long Count cycle
+ * Long Count cycle.
+ * 
+ * The Long Count is a mixed-radix numeral system used by the ancient Maya to track
+ * days elapsed since a creation-era base date. This implementation uses the standard
+ * epoch per scholarly literature [R1, R2]:
+ * 
+ * **Epoch (Maya Day Number (MDN) = 0): 13.0.0.0.0 4 Ajaw 8 Kumk'u**
+ * 
+ * This date represents the completion of the 13th bak'tun in Maya cosmology and serves
+ * as the anchor for all Long Count calculations and correlation with Western calendars.
+ * MDN is analogous to Julian Day Number, but for the Maya calendar system.
+ * 
+ * **Units (mixed-radix system):**
+ * - 1 k'in = 1 day
+ * - 1 winal = 20 k'in
+ * - 1 tun = 18 winal = 360 days
+ * - 1 k'atun = 20 tun = 7,200 days
+ * - 1 bak'tun = 20 k'atun = 144,000 days
+ * 
+ * @see Reingold, Dershowitz, & Clamen (1993) [R1]
+ * @see Martin & Skidmore (2012) [R2]
  */
 export default class LongCount extends DistanceNumber {
 


### PR DESCRIPTION
## Summary
Part of spec alignment series (5/10) - see #75

Documents the epoch choice (13.0.0.0.0 4 Ajaw 8 Kumk'u) with scholarly rationale.

## Changes
- Comprehensive documentation of epoch in `calendar-round.ts` (origin constant)
- Long Count class header with mixed-radix system documentation
- Explains why alternatives (royal coronations) aren't used
- References [R1] Reingold & Dershowitz (1993) and [R2] Martin & Skidmore (2012)

## Rationale Documented
- Scholarly standard per academic literature
- Compatibility with GMT correlation family
- Maya cosmology (completion of 13th bak'tun)

## Testing
✅ Type-check passes
✅ Documentation-only changes, no functional impact

**Labels:** `spec-alignment`, `documentation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the Maya epoch and Long Count system for maintainers and users. Documentation-only changes.
> 
> - Adds comprehensive epoch docs for `origin` in `calendar-round.ts` (4 Ajaw 8 Kumk'u ↔ 13.0.0.0.0), including scholarly rationale, alternatives, and references [R1, R2]
> - Expands `LongCount` class header with epoch definition (MDN = 0), mixed‑radix unit breakdown, and citations [R1, R2]
> - No runtime behavior or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8591ae5534274dfd7e125d5829c0aff2f72bce6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->