### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: Node CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/drewsonne/maya-dates/security/code-scanning/8](https://github.com/drewsonne/maya-dates/security/code-scanning/8)

In general, this should be fixed by explicitly defining a `permissions` block either at the top level of the workflow (to apply to all jobs) or within the specific job. Since the shown workflow only has a `build` job and it just needs to check out code and run tests, it can safely restrict `GITHUB_TOKEN` to read-only repository contents.

The best minimal fix here is to add a root-level `permissions` section after the `name:` (and before `on:`) that sets `contents: read`. This aligns with CodeQL’s suggested minimal starting point and does not change the existing functionality of the workflow: checkout and reading source code still work, and no step requires write permissions. Concretely, in `.github/workflows/nodejs.yml`, add:

```yaml
permissions:
  contents: read
```

right after line 1 (`name: Node CI`). No imports or additional definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
